### PR TITLE
fix/availability initial month

### DIFF
--- a/src/app/dashboard/disponibilidad/page.tsx
+++ b/src/app/dashboard/disponibilidad/page.tsx
@@ -484,6 +484,15 @@ export default function AvailabilityDashboard() {
                 availabilityData={availabilityData}
                 viewMode="availability"
                 initialMonth={currentDate}
+                onMonthChange={(month) => {
+                  // If parent month differs, update and reload
+                  if (
+                    month.getFullYear() !== currentDate.getFullYear() ||
+                    month.getMonth() !== currentDate.getMonth()
+                  ) {
+                    setCurrentDate(month);
+                  }
+                }}
               />
             ) : (
               <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm h-full flex items-center justify-center">

--- a/src/components/availability/ProfessionalCalendarMinimal.tsx
+++ b/src/components/availability/ProfessionalCalendarMinimal.tsx
@@ -37,6 +37,7 @@ interface ProfessionalCalendarProps {
   availabilityData: any;
   viewMode?: 'availability' | 'pricing' | 'selection';
   initialMonth?: Date; // Align calendar with loaded data window
+  onMonthChange?: (month: Date) => void; // Notify parent when user navigates months
 }
 
 export default function ProfessionalCalendarMinimal({
@@ -47,7 +48,8 @@ export default function ProfessionalCalendarMinimal({
   onPriceUpdate,
   availabilityData,
   viewMode: initialViewMode = 'availability',
-  initialMonth
+  initialMonth,
+  onMonthChange
 }: ProfessionalCalendarProps) {
   const { company } = useCompany();
   const currency = (company as any)?.storeCurrency || company?.currency || '$';
@@ -62,6 +64,15 @@ export default function ProfessionalCalendarMinimal({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialMonth?.getFullYear(), initialMonth?.getMonth()]);
+
+  // Inform parent when the visible month changes so it can reload data
+  useEffect(() => {
+    if (onMonthChange) {
+      const normalized = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
+      onMonthChange(normalized);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentMonth.getFullYear(), currentMonth.getMonth()]);
   const [selectedStartDate, setSelectedStartDate] = useState<Date | null>(null);
   const [selectedEndDate, setSelectedEndDate] = useState<Date | null>(null);
   const [hoveredDate, setHoveredDate] = useState<Date | null>(null);
@@ -388,7 +399,10 @@ export default function ProfessionalCalendarMinimal({
           {/* Month navigation */}
           <div className="flex items-center gap-1 md:gap-2">
             <button
-              onClick={() => setCurrentMonth(new Date(currentMonth.setMonth(currentMonth.getMonth() - 1)))}
+              onClick={() => {
+                const prev = new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1);
+                setCurrentMonth(prev);
+              }}
               className="p-0.5 md:p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
             >
               <ChevronLeft className="w-3 h-3 md:w-3.5 md:h-3.5 text-gray-600 dark:text-gray-400" />
@@ -399,7 +413,10 @@ export default function ProfessionalCalendarMinimal({
             </span>
             
             <button
-              onClick={() => setCurrentMonth(new Date(currentMonth.setMonth(currentMonth.getMonth() + 1)))}
+              onClick={() => {
+                const next = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1);
+                setCurrentMonth(next);
+              }}
               className="p-0.5 md:p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
             >
               <ChevronRight className="w-3 h-3 md:w-3.5 md:h-3.5 text-gray-600 dark:text-gray-400" />


### PR DESCRIPTION
- fix(mapbox): disable map when token invalid or secret (sk.*), reinit on token change; never block forms
- fix(whatsapp): disable auto-scroll on first open; only auto-stick after user near-bottom; add robust scroll guards\nfix(map): pass Mapbox token on public room template using company token or env fallback; use token for geocoding too
- fix(whatsapp): no auto-scroll on first open; add grace period; only auto-stick after user near-bottom; initial load uses conversation detail to avoid flicker
- fix(build): remove duplicate allowAutoScrollRef declaration
- fix(whatsapp): on re-open, auto-stick to bottom using cached messages; first-time opens keep no auto-scroll with grace period
- fix(whatsapp): handle media loads (img/video) with final bottom scroll; disable overflow-anchor to prevent pinning; ensure re-open sticks to bottom
- fix(whatsapp): avoid extra reload when switching to media-heavy threads; disable quick retries on reopen; threshold for 'conversationUpdated' reloads
- perf(whatsapp): instant scroll (no animation); trim first paint to last 20 msgs; lazy/async images and metadata-only videos to speed initial render
- fix(public map): expose NEXT_PUBLIC_MAPBOX_TOKEN in public layout; LocationMap/Preview fallback to window or env token; add loading skeleton for public room page to avoid flashes
- fix: Fix menu navigation and Next.js 15 params issue
- fix(navigation): corregir navegación con handles customizados en preview real
- fix(websitebuilder): - Remove structural ImageBanner fallback (render only as section) - Include header ImageBanner in page save (frontend + backend payload) - Fix FeaturedCollection effect deps + avoid nested anchors in clickable cards - Use getApiUrl for Reviews API (create/upload/list/public room) to prevent relative 404 and HTML dumps
- fix: usar endpoint publico para habitaciones-lista cuando no hay autenticacion - Detectar contexto publico vs autenticado en fetchRooms - Usar api/Rooms/company/id/public para visitantes sin token - Mantener api/Rooms con auth para usuarios autenticados - Prevenir redireccion al login desde paginas publicas
- fix(preview): pass theme to PreviewImageBanner for correct color scheme; normalize internal nav URLs (e.g., /habitaciones-lista -> /habitaciones) in public header
- fix(theme): PreviewImageWithText uses provided theme (live preview) instead of store; ensure ImageBanner and others receive theme; normalize header internal paths for public
- fix(public): prevent 401 interceptor from redirecting public pages to /login; restrict redirect to protected routes
- fix(public): initialize Mapbox token globally (env or public API); normalize header/footer/host images to avoid mixed content
- fix(availability): align calendar month with loaded data and normalize media URLs
- fix(availability): parent reloads data on month navigation\n\n- Add onMonthChange callback from calendar to dashboard\n- Normalize month state and avoid Date.setMonth mutation
