### PR TITLE
fix/availability initial month

### DIFF
--- a/src/components/clientes/CustomersList.tsx
+++ b/src/components/clientes/CustomersList.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Customer, CustomerFilter, customerAPI } from '@/lib/api/customers';
+import { getImageUrl } from '@/lib/api-url';
+import { getInitials } from '@/lib/utils';
 import { useI18n } from '@/contexts/I18nContext';
 import { 
   Search, 

--- a/src/components/clientes/CustomersList.tsx
+++ b/src/components/clientes/CustomersList.tsx
@@ -330,9 +330,17 @@ export function CustomersList() {
                         <div className="flex-shrink-0">
                           {customer.avatar ? (
                             <img
-                              src={customer.avatar}
+                              src={getImageUrl(customer.avatar)}
                               alt={customer.fullName}
                               className="w-10 h-10 rounded-lg object-cover"
+                              onError={(e) => {
+                                e.currentTarget.style.display = 'none';
+                                const fallback = document.createElement('div');
+                                fallback.className = 'w-10 h-10 rounded-lg flex items-center justify-center text-white font-semibold';
+                                (fallback as any).style = `background-color: ${primaryColor}`;
+                                fallback.innerText = getInitials(customer.fullName);
+                                e.currentTarget.parentElement?.appendChild(fallback);
+                              }}
                             />
                           ) : (
                             <div 

--- a/src/components/preview/PreviewHeader.tsx
+++ b/src/components/preview/PreviewHeader.tsx
@@ -595,6 +595,7 @@ export default function PreviewHeader({ config, theme, deviceView, isEditor = fa
                           height: isMobile ? (headerConfig.logo.mobileHeight || 30) : (headerConfig.logo.height || 40),
                           objectFit: 'contain'
                         }}
+                        onError={(e) => { e.currentTarget.style.display = 'none'; }}
                       />
                     ) : (
                       <div className="text-xl font-bold self-center" style={{ color: colorScheme?.text?.default || '#000000' }}>
@@ -615,6 +616,7 @@ export default function PreviewHeader({ config, theme, deviceView, isEditor = fa
                         height: isMobile ? (headerConfig.logo.mobileHeight || 30) : (headerConfig.logo.height || 40),
                         objectFit: 'contain'
                       }}
+                      onError={(e) => { e.currentTarget.style.display = 'none'; }}
                     />
                   ) : (
                     <div className="text-xl font-bold self-center" style={{ color: colorScheme?.text?.default || '#000000' }}>


### PR DESCRIPTION
- fix(mapbox): disable map when token invalid or secret (sk.*), reinit on token change; never block forms
- fix(whatsapp): disable auto-scroll on first open; only auto-stick after user near-bottom; add robust scroll guards\nfix(map): pass Mapbox token on public room template using company token or env fallback; use token for geocoding too
- fix(whatsapp): no auto-scroll on first open; add grace period; only auto-stick after user near-bottom; initial load uses conversation detail to avoid flicker
- fix(build): remove duplicate allowAutoScrollRef declaration
- fix(whatsapp): on re-open, auto-stick to bottom using cached messages; first-time opens keep no auto-scroll with grace period
- fix(whatsapp): handle media loads (img/video) with final bottom scroll; disable overflow-anchor to prevent pinning; ensure re-open sticks to bottom
- fix(whatsapp): avoid extra reload when switching to media-heavy threads; disable quick retries on reopen; threshold for 'conversationUpdated' reloads
- perf(whatsapp): instant scroll (no animation); trim first paint to last 20 msgs; lazy/async images and metadata-only videos to speed initial render
- fix(public map): expose NEXT_PUBLIC_MAPBOX_TOKEN in public layout; LocationMap/Preview fallback to window or env token; add loading skeleton for public room page to avoid flashes
- fix: Fix menu navigation and Next.js 15 params issue
- fix(navigation): corregir navegación con handles customizados en preview real
- fix(websitebuilder): - Remove structural ImageBanner fallback (render only as section) - Include header ImageBanner in page save (frontend + backend payload) - Fix FeaturedCollection effect deps + avoid nested anchors in clickable cards - Use getApiUrl for Reviews API (create/upload/list/public room) to prevent relative 404 and HTML dumps
- fix: usar endpoint publico para habitaciones-lista cuando no hay autenticacion - Detectar contexto publico vs autenticado en fetchRooms - Usar api/Rooms/company/id/public para visitantes sin token - Mantener api/Rooms con auth para usuarios autenticados - Prevenir redireccion al login desde paginas publicas
- fix(preview): pass theme to PreviewImageBanner for correct color scheme; normalize internal nav URLs (e.g., /habitaciones-lista -> /habitaciones) in public header
- fix(theme): PreviewImageWithText uses provided theme (live preview) instead of store; ensure ImageBanner and others receive theme; normalize header internal paths for public
- fix(public): prevent 401 interceptor from redirecting public pages to /login; restrict redirect to protected routes
- fix(public): initialize Mapbox token globally (env or public API); normalize header/footer/host images to avoid mixed content
- fix(availability): align calendar month with loaded data and normalize media URLs
- fix(availability): parent reloads data on month navigation\n\n- Add onMonthChange callback from calendar to dashboard\n- Normalize month state and avoid Date.setMonth mutation
- chore(media): normalize avatar/logo URLs and add graceful fallback to reduce 404 noise\n\n- CustomersList: use getImageUrl + onError fallback\n- PreviewHeader: add onError fallback for logo image
