### PR TITLE
feat(customers): payments-history API + base currency in billing tab

### DIFF
--- a/src/components/clientes/tabs/CustomerAddressBillingTab.tsx
+++ b/src/components/clientes/tabs/CustomerAddressBillingTab.tsx
@@ -6,6 +6,7 @@ import { CustomerDetailDto } from '@/types/customer';
 import { AddressBillingFormData } from '../CustomerDetail';
 import { customerAPI } from '@/lib/api/customers';
 import { CountryFlag, countries } from '@/components/ui/CountryFlag';
+import { useCurrency } from '@/contexts/CurrencyContext';
 
 interface CustomerAddressBillingTabProps {
   customer: CustomerDetailDto | null;
@@ -29,16 +30,18 @@ export default function CustomerAddressBillingTab({
   setIsEditing
 }: CustomerAddressBillingTabProps) {
   const { t } = useI18n();
+  const { baseCurrency } = useCurrency();
   const [useSameAddress, setUseSameAddress] = useState(false);
   const [payments, setPayments] = useState<Array<{ reservationId: number; amount: number; method: string; status: string; date: string; transactionId?: string }>>([]);
   const formatMoney = (amount?: number, currency?: string) => {
     if (amount === undefined || amount === null) return '-';
     try {
-      if (!currency) return amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-      const formatted = new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount);
-      return `${currency} ${formatted.replace(/[^0-9.,\s]/g, '').trim()}`;
+      const cur = currency || baseCurrency || 'DOP';
+      if (!cur) return amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+      const formatted = new Intl.NumberFormat(undefined, { style: 'currency', currency: cur as any }).format(amount);
+      return `${cur} ${formatted.replace(/[^0-9.,\s]/g, '').trim()}`;
     } catch {
-      return `${currency || ''} ${amount.toFixed(2)}`.trim();
+      return `${currency || baseCurrency || ''} ${amount.toFixed(2)}`.trim();
     }
   };
   
@@ -111,19 +114,19 @@ export default function CustomerAddressBillingTab({
     }
   }, []); // Empty dependency array - only run once on mount
 
-  // Load payments history for this customer (by email)
+  // Load payments history for this customer (by customerId)
   useEffect(() => {
     (async () => {
       try {
-        if (customer?.email) {
-          const list = await customerAPI.getCustomerPaymentsByEmail(customer.email);
+        if (customer?.id) {
+          const list = await customerAPI.getCustomerPayments(customer.id);
           setPayments(list);
         }
       } catch (e) {
         // ignore
       }
     })();
-  }, [customer?.email]);
+  }, [customer?.id]);
 
   return (
     <div className="relative min-h-screen pb-20 md:pb-6">
@@ -142,7 +145,7 @@ export default function CustomerAddressBillingTab({
             <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-4">
               <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{t('customers.overview.totalSpent', 'Monto total gastado')}</p>
               <p className="text-gray-900 dark:text-white font-medium">
-                {formatMoney(customer?.totalSpent, customer?.preferredCurrency || 'DOP')}
+                {formatMoney(customer?.totalSpent, baseCurrency)}
               </p>
             </div>
           </div>
@@ -173,7 +176,7 @@ export default function CustomerAddressBillingTab({
                     {payments.map((p, idx) => (
                       <tr key={idx}>
                         <td className="px-4 py-2">{new Date(p.date).toLocaleString()}</td>
-                        <td className="px-4 py-2">{formatMoney(p.amount, customer?.preferredCurrency || 'DOP')}</td>
+                        <td className="px-4 py-2">{formatMoney(p.amount, baseCurrency)}</td>
                         <td className="px-4 py-2">{p.method}</td>
                         <td className="px-4 py-2">{p.status}</td>
                         <td className="px-4 py-2">#{p.reservationId}</td>


### PR DESCRIPTION
- Use new backend endpoint /api/customers/{id}/payments-history\n- Replace email-based aggregation\n- Use base store currency from CurrencyContext to format totals and history.\n\nThis PR aligns with CLAUDE.md rules and avoids N+1 calls via /reservations.